### PR TITLE
Add link to alfred-hotel to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -509,6 +509,7 @@ Non-synced local preferences are stored within `Alfred.alfredpreferences` under 
 - [alfred-vue](https://github.com/radibit/alfred-vue) - Search the Vue.js API docs
 - [alfred-meteor-docs](https://github.com/wolasss/alfred-meteor-docs) - Search the Meteor docs
 - [alfred-climbing-grades-converter](https://github.com/wolasss/alfred-climbing-grades-converter) - Convert between climbing grading systems
+- [alfred-hotel](https://github.com/exah/alfred-hotel) - Quickly start, stop and open [Hotel](https://github.com/typicode/hotel) apps
 
 
 ## Related


### PR DESCRIPTION
Hi, this PR just adds link to `alfred-hotel` workflow in Users section of readme. Thanks!